### PR TITLE
Modified metadata.json so Gnome Shell 3.8 is supported

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "gnomodoro@mancinelli.me",
     "name": "Gnomodoro",
     "description": "A pomodoro timer for Gnome Shell",
-    "shell-version": ["3.6"],
+    "shell-version": ["3.8"],
     "url": "https://github.com/fmancinelli/gnomodoro",
-    "version": "1.1-SNAPSHOT"
+    "version": "1.1-SNAPSHOT_3.8"
 }


### PR DESCRIPTION
It's a trivial change, but maybe you still want to use it :-)
