### PR TITLE
Update for version 3.18

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "gnomodoro@mancinelli.me",
     "name": "Gnomodoro",
     "description": "A pomodoro timer for Gnome Shell",
-    "shell-version": ["3.6"],
+    "shell-version": ["3.18"],
     "url": "https://github.com/fmancinelli/gnomodoro",
     "version": "1.1-SNAPSHOT"
 }


### PR DESCRIPTION
Change the metadata.json to enable gnome-shell 3.18
